### PR TITLE
chore: add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.py]
+indent_size = 4
+
+[*.ipynb]
+indent_size = 1
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Adds a small EditorConfig file to keep whitespace and indentation consistent across editors and notebook-adjacent files.